### PR TITLE
BUG: fix trim_overlaps function

### DIFF
--- a/geoplanar/overlap.py
+++ b/geoplanar/overlap.py
@@ -62,9 +62,9 @@ def trim_overlaps(gdf, strategy='largest', inplace=False):
 
     """
     if GPD_GE_014:
-        intersections = gdf.sindex.query(gdf.geometry, predicate="intersects").T
+        intersections = gdf.sindex.query(gdf.geometry, predicate="overlaps").T
     else:
-        intersections = gdf.sindex.query_bulk(gdf.geometry, predicate="intersects").T
+        intersections = gdf.sindex.query_bulk(gdf.geometry, predicate="overlaps").T
 
     if not inplace:
         gdf = gdf.copy()


### PR DESCRIPTION
Found an issue in the trim_overlaps function. The spatial index query should use predicate "overlaps" not "intersects". Tested this out in the example notebook on building footprints (will create a PR for this soon)